### PR TITLE
Async with support for executing task code within worker processes

### DIFF
--- a/luigi/event.py
+++ b/luigi/event.py
@@ -29,6 +29,7 @@ class Event(object):
     #: for the task to report progress, metadata or any generic info so that
     #: event handler listening for this can keep track of the progress of running task.
     PROGRESS = "event.core.progress"
+    SUBMIT = "event.core.submit"
     FAILURE = "event.core.failure"
     SUCCESS = "event.core.success"
     PROCESSING_TIME = "event.core.processing_time"

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ if os.environ.get('READTHEDOCS', None) == 'True':
 
 setup(
     name='luigi',
-    version='2.8.0.post2',
+    version='2.8.0.post2.dev1',
     description='Workflow mgmgt + task scheduling + dependency resolution',
     long_description=long_description,
     author='The Luigi Authors',


### PR DESCRIPTION
Existence of `poll_status` method on task makes it async task.

The end of `run` method on async task doesn't mark completion. Instead the previously mentioned `poll_status` task is called every `poll_frequency` seconds until it return true or raises an error indicating failure. 

