### PR TITLE
Don't filter any task nodes in graph view.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ if os.environ.get('READTHEDOCS', None) == 'True':
 
 setup(
     name='luigi',
-    version='2.8.0.post4rc1',
+    version='2.8.0.post4',
     description='Workflow mgmgt + task scheduling + dependency resolution',
     long_description=long_description,
     author='The Luigi Authors',


### PR DESCRIPTION
With sawyer3, we no longer have `KubernatesWait` and `pluck` tasks and far fewer `UploadTask` (because each can upload many files). Thus, we should now stop filtering the DAG and show exactly what is being processed. 

This PR removes all task/node filtering.