### PR TITLE
Log traceback for failures in submitting task

### DIFF
--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -1005,9 +1005,7 @@ class Worker(object):
             task._start_time = time.time()
             task.submit_task()
         except Exception as ex:
-            logger.error("Error in submitting task: %s %s", task.task_id, ex)
-            formatted_traceback = traceback.format_exc()
-            logger.debug(formatted_traceback)
+            logger.exception("Error in submitting task: %s %s", task.task_id, ex)
             # Notify scheduler that task submission failed
             self._add_task(
                 worker=self._id,

--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -1006,6 +1006,8 @@ class Worker(object):
             task.submit_task()
         except Exception as ex:
             logger.error("Error in submitting task: %s %s", task.task_id, ex)
+            formatted_traceback = traceback.format_exc()
+            logger.debug(formatted_traceback)
             # Notify scheduler that task submission failed
             self._add_task(
                 worker=self._id,


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->
Currently, when there's an error in the process of submitting a task we only log what the error is. This adds the traceback.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I was trying to find a bug in my pipeline code with only the hint that it was `'dict' object is not callable`. So i had to add print statements on every line in several classes until i found it.

But with this change, one would be able to tell which exact line this bug was on. 
<!--- If it fixes an open issue, please link to the issue here. -->

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
Basically no, but I would really like to, but I'm not sure how, since this is my first commit to this repo and I'm not sure how to get it running for real.
<!--- "I ran my jobs with this code and it works for me." -->

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
